### PR TITLE
Fix: content protocol didn't close a file download correctly

### DIFF
--- a/openttd_protocol/protocol/content.py
+++ b/openttd_protocol/protocol/content.py
@@ -234,6 +234,6 @@ class ContentProtocol(TCPProtocol):
             write_presend(data, SEND_TCP_COMPAT_MTU)
             await self.send_packet(data)
 
-        write_init(PacketContentType.PACKET_CONTENT_SERVER_CONTENT)
+        data = write_init(PacketContentType.PACKET_CONTENT_SERVER_CONTENT)
         write_presend(data, SEND_TCP_COMPAT_MTU)
         await self.send_packet(data)


### PR DESCRIPTION
It basically resend the last packet, instead of an empty one.