### PR TITLE
Add: application performance monitoring via Honeycomb

### DIFF
--- a/openttd_protocol/protocol/content.py
+++ b/openttd_protocol/protocol/content.py
@@ -2,6 +2,7 @@ import enum
 import logging
 import struct
 
+from .. import tracer
 from ..wire.exceptions import PacketInvalidData
 from ..wire.read import (
     read_string,
@@ -71,6 +72,7 @@ class ContentProtocol(TCPProtocol):
     PACKET_END = PacketContentType.PACKET_CONTENT_END
 
     @staticmethod
+    @tracer.traced("content")
     def receive_PACKET_CONTENT_CLIENT_INFO_LIST(source, data):
         content_type, data = read_uint8(data)
         openttd_version, data = read_uint32(data)
@@ -141,6 +143,7 @@ class ContentProtocol(TCPProtocol):
         return content_infos, data
 
     @classmethod
+    @tracer.traced("content")
     def receive_PACKET_CONTENT_CLIENT_INFO_ID(cls, source, data):
         count, data = read_uint16(data)
 
@@ -152,6 +155,7 @@ class ContentProtocol(TCPProtocol):
         return {"content_infos": content_infos}
 
     @classmethod
+    @tracer.traced("content")
     def receive_PACKET_CONTENT_CLIENT_INFO_EXTID(cls, source, data):
         count, data = read_uint8(data)
 
@@ -163,6 +167,7 @@ class ContentProtocol(TCPProtocol):
         return {"content_infos": content_infos}
 
     @classmethod
+    @tracer.traced("content")
     def receive_PACKET_CONTENT_CLIENT_INFO_EXTID_MD5(cls, source, data):
         count, data = read_uint8(data)
 
@@ -176,6 +181,7 @@ class ContentProtocol(TCPProtocol):
         return {"content_infos": content_infos}
 
     @classmethod
+    @tracer.traced("content")
     def receive_PACKET_CONTENT_CLIENT_CONTENT(cls, source, data):
         count, data = read_uint16(data)
 
@@ -186,6 +192,7 @@ class ContentProtocol(TCPProtocol):
 
         return {"content_infos": content_infos}
 
+    @tracer.traced("content")
     async def send_PACKET_CONTENT_SERVER_INFO(
         self, content_type, content_id, filesize, name, version, url, description, unique_id, md5sum, dependencies, tags
     ):
@@ -227,6 +234,7 @@ class ContentProtocol(TCPProtocol):
         write_presend(data, SEND_TCP_COMPAT_MTU)
         await self.send_packet(data)
 
+    @tracer.traced("content")
     async def send_PACKET_CONTENT_SERVER_CONTENT(self, content_type, content_id, filesize, filename, stream):
         # First, send a packet to tell the client it will be receiving a file
         data = write_init(PacketContentType.PACKET_CONTENT_SERVER_CONTENT)

--- a/openttd_protocol/protocol/coordinator.py
+++ b/openttd_protocol/protocol/coordinator.py
@@ -1,6 +1,7 @@
 import enum
 import logging
 
+from .. import tracer
 from ..wire.exceptions import PacketInvalidData
 from ..wire.read import (
     read_bytes,
@@ -94,6 +95,7 @@ class CoordinatorProtocol(TCPProtocol):
     PACKET_END = PacketCoordinatorType.PACKET_COORDINATOR_END
 
     @staticmethod
+    @tracer.traced("coordinator")
     def receive_PACKET_COORDINATOR_SERVER_REGISTER(source, data):
         protocol_version, data = read_uint8(data)
 
@@ -128,6 +130,7 @@ class CoordinatorProtocol(TCPProtocol):
         }
 
     @staticmethod
+    @tracer.traced("coordinator")
     def receive_PACKET_COORDINATOR_SERVER_UPDATE(source, data):
         protocol_version, data = read_uint8(data)
 
@@ -240,6 +243,7 @@ class CoordinatorProtocol(TCPProtocol):
         }
 
     @staticmethod
+    @tracer.traced("coordinator")
     def receive_PACKET_COORDINATOR_CLIENT_LISTING(source, data):
         protocol_version, data = read_uint8(data)
 
@@ -268,6 +272,7 @@ class CoordinatorProtocol(TCPProtocol):
         }
 
     @staticmethod
+    @tracer.traced("coordinator")
     def receive_PACKET_COORDINATOR_CLIENT_CONNECT(source, data):
         protocol_version, data = read_uint8(data)
 
@@ -285,6 +290,7 @@ class CoordinatorProtocol(TCPProtocol):
         }
 
     @staticmethod
+    @tracer.traced("coordinator")
     def receive_PACKET_COORDINATOR_SERCLI_CONNECT_FAILED(source, data):
         protocol_version, data = read_uint8(data)
 
@@ -304,6 +310,7 @@ class CoordinatorProtocol(TCPProtocol):
         }
 
     @staticmethod
+    @tracer.traced("coordinator")
     def receive_PACKET_COORDINATOR_CLIENT_CONNECTED(source, data):
         protocol_version, data = read_uint8(data)
 
@@ -321,6 +328,7 @@ class CoordinatorProtocol(TCPProtocol):
         }
 
     @staticmethod
+    @tracer.traced("coordinator")
     def receive_PACKET_COORDINATOR_SERCLI_STUN_RESULT(source, data):
         protocol_version, data = read_uint8(data)
 
@@ -341,6 +349,7 @@ class CoordinatorProtocol(TCPProtocol):
             "result": result,
         }
 
+    @tracer.traced("coordinator")
     async def send_PACKET_COORDINATOR_GC_ERROR(self, protocol_version, error_no, error_detail):
         data = write_init(PacketCoordinatorType.PACKET_COORDINATOR_GC_ERROR)
 
@@ -358,6 +367,7 @@ class CoordinatorProtocol(TCPProtocol):
         write_presend(data, SEND_TCP_MTU)
         await self.send_packet(data)
 
+    @tracer.traced("coordinator")
     async def send_PACKET_COORDINATOR_GC_REGISTER_ACK(
         self, protocol_version, connection_type, invite_code, invite_code_secret
     ):
@@ -396,6 +406,7 @@ class CoordinatorProtocol(TCPProtocol):
         if count != 0:
             yield count, data
 
+    @tracer.traced("coordinator")
     async def send_PACKET_COORDINATOR_GC_NEWGRF_LOOKUP(
         self, protocol_version, newgrf_lookup_table_cursor, newgrf_lookup_table
     ):
@@ -413,6 +424,7 @@ class CoordinatorProtocol(TCPProtocol):
             write_presend(data, SEND_TCP_MTU)
             await self.send_packet(data)
 
+    @tracer.traced("coordinator")
     async def send_PACKET_COORDINATOR_GC_LISTING(
         self, protocol_version, game_info_version, servers, newgrf_lookup_table
     ):
@@ -491,6 +503,7 @@ class CoordinatorProtocol(TCPProtocol):
         write_presend(data, SEND_TCP_MTU)
         await self.send_packet(data)
 
+    @tracer.traced("coordinator")
     async def send_PACKET_COORDINATOR_GC_CONNECTING(self, protocol_version, token, invite_code):
         data = write_init(PacketCoordinatorType.PACKET_COORDINATOR_GC_CONNECTING)
 
@@ -500,6 +513,7 @@ class CoordinatorProtocol(TCPProtocol):
         write_presend(data, SEND_TCP_MTU)
         await self.send_packet(data)
 
+    @tracer.traced("coordinator")
     async def send_PACKET_COORDINATOR_GC_CONNECT_FAILED(self, protocol_version, token):
         data = write_init(PacketCoordinatorType.PACKET_COORDINATOR_GC_CONNECT_FAILED)
 
@@ -508,6 +522,7 @@ class CoordinatorProtocol(TCPProtocol):
         write_presend(data, SEND_TCP_MTU)
         await self.send_packet(data)
 
+    @tracer.traced("coordinator")
     async def send_PACKET_COORDINATOR_GC_DIRECT_CONNECT(self, protocol_version, token, tracking_number, hostname, port):
         data = write_init(PacketCoordinatorType.PACKET_COORDINATOR_GC_DIRECT_CONNECT)
 
@@ -519,6 +534,7 @@ class CoordinatorProtocol(TCPProtocol):
         write_presend(data, SEND_TCP_MTU)
         await self.send_packet(data)
 
+    @tracer.traced("coordinator")
     async def send_PACKET_COORDINATOR_GC_STUN_REQUEST(self, protocol_version, token):
         data = write_init(PacketCoordinatorType.PACKET_COORDINATOR_GC_STUN_REQUEST)
 
@@ -527,6 +543,7 @@ class CoordinatorProtocol(TCPProtocol):
         write_presend(data, SEND_TCP_MTU)
         await self.send_packet(data)
 
+    @tracer.traced("coordinator")
     async def send_PACKET_COORDINATOR_GC_STUN_CONNECT(
         self, protocol_version, token, tracking_number, interface_number, hostname, port
     ):
@@ -541,6 +558,7 @@ class CoordinatorProtocol(TCPProtocol):
         write_presend(data, SEND_TCP_MTU)
         await self.send_packet(data)
 
+    @tracer.traced("coordinator")
     async def send_PACKET_COORDINATOR_GC_TURN_CONNECT(
         self, protocol_version, token, tracking_number, ticket, connection_string
     ):

--- a/openttd_protocol/protocol/game.py
+++ b/openttd_protocol/protocol/game.py
@@ -1,6 +1,7 @@
 import enum
 import logging
 
+from .. import tracer
 from ..wire.exceptions import PacketInvalidData
 from ..wire.read import (
     read_bytes,
@@ -53,6 +54,7 @@ class GameProtocol(TCPProtocol):
     PACKET_END = PacketGameType.PACKET_END
 
     @staticmethod
+    @tracer.traced("game")
     def receive_PACKET_SERVER_GAME_INFO(source, data):
         game_info_version, data = read_uint8(data)
 
@@ -158,12 +160,14 @@ class GameProtocol(TCPProtocol):
         }
 
     @staticmethod
+    @tracer.traced("game")
     def receive_PACKET_SERVER_SHUTDOWN(source, data):
         if len(data) != 0:
             raise PacketInvalidData("more bytes than expected in SERVER_SHUTDOWN; remaining: ", len(data))
 
         return {}
 
+    @tracer.traced("game")
     async def send_PACKET_CLIENT_GAME_INFO(self):
         data = write_init(PacketGameType.PACKET_CLIENT_GAME_INFO)
         write_presend(data, SEND_TCP_MTU)

--- a/openttd_protocol/protocol/stun.py
+++ b/openttd_protocol/protocol/stun.py
@@ -1,6 +1,7 @@
 import enum
 import logging
 
+from .. import tracer
 from ..wire.exceptions import PacketInvalidData
 from ..wire.read import (
     read_string,
@@ -21,6 +22,7 @@ class StunProtocol(TCPProtocol):
     PACKET_END = PacketStunType.PACKET_STUN_END
 
     @staticmethod
+    @tracer.traced("stun")
     def receive_PACKET_STUN_SERCLI_STUN(source, data):
         protocol_version, data = read_uint8(data)
 

--- a/openttd_protocol/protocol/turn.py
+++ b/openttd_protocol/protocol/turn.py
@@ -1,6 +1,7 @@
 import enum
 import logging
 
+from .. import tracer
 from ..wire.exceptions import PacketInvalidData
 from ..wire.read import (
     read_string,
@@ -29,6 +30,7 @@ class TurnProtocol(TCPProtocol):
     PACKET_END = PacketTurnType.PACKET_TURN_END
 
     @staticmethod
+    @tracer.traced("turn")
     def receive_PACKET_TURN_SERCLI_CONNECT(source, data):
         protocol_version, data = read_uint8(data)
 
@@ -42,6 +44,7 @@ class TurnProtocol(TCPProtocol):
 
         return {"protocol_version": protocol_version, "ticket": ticket}
 
+    @tracer.traced("turn")
     async def send_PACKET_TURN_TURN_CONNECTED(self, protocol_version, hostname):
         data = write_init(PacketTurnType.PACKET_TURN_TURN_CONNECTED)
 

--- a/openttd_protocol/tracer.py
+++ b/openttd_protocol/tracer.py
@@ -1,0 +1,38 @@
+try:
+    import beeline
+
+    def traced(prefix):
+        # The common case is to use the function-name, so automate this.
+        def wrapper(func):
+            return beeline.traced_impl(beeline.tracer, f"{prefix}.{func.__name__}", None, None)(func)
+
+        return wrapper
+
+    tracer = beeline.tracer
+    untraced = beeline.untraced
+    add_context = beeline.add_context
+
+except ImportError:
+    # Honeycomb Beeline package is not installed. Mock the tracer functions.
+
+    def traced(prefix):
+        def wrapper(func):
+            return func
+
+        return wrapper
+
+    class tracer:
+        def __init__(self, name):
+            pass
+
+        def __enter__(self):
+            pass
+
+        def __exit__(self, type, value, traceback):
+            pass
+
+    def untraced(func):
+        return func
+
+    def add_context(payload):
+        pass


### PR DESCRIPTION
If you don't have "honeycomb-beeline" package installed, it doesn't
do anything.
If you do have it installed, it ensure all important functions
are traced.

By default, this library creates a new trace for each new incoming
packet. For all other cases it is up to the application to make
good traces out of this.