### PR TITLE
Fix: use add_trace_field() over add_context() for tracer

### DIFF
--- a/openttd_protocol/tracer.py
+++ b/openttd_protocol/tracer.py
@@ -10,7 +10,7 @@ try:
 
     tracer = beeline.tracer
     untraced = beeline.untraced
-    add_context = beeline.add_context
+    add_trace_field = beeline.add_trace_field
 
 except ImportError:
     # Honeycomb Beeline package is not installed. Mock the tracer functions.
@@ -34,5 +34,5 @@ except ImportError:
     def untraced(func):
         return func
 
-    def add_context(payload):
+    def add_trace_field(key, value):
         pass


### PR DESCRIPTION
This way all events are marked with the command they operate under,
instead of only the root event. This makes sampling a lot easier,
as we know the command we are doing it for.